### PR TITLE
More patches

### DIFF
--- a/dime-note-tree.el
+++ b/dime-note-tree.el
@@ -98,7 +98,7 @@ This command is meant to be bound to a mouse EVENT."
       (goto-char pos)
       (let ((fn (get-text-property (point)
                                    'dime-compiler-notes-default-action)))
-	(if fn (funcall fn) (dime-note-tree-show-details))))))
+        (if fn (funcall fn) (dime-note-tree-show-details))))))
 
 (defun dime-note-tree-default-action-or-show-details ()
   "Invoke the action at point, or show details."
@@ -141,19 +141,19 @@ This command is meant to be bound to a mouse EVENT."
 (defun dime-note-tree--decoration (tree)
   "Return decorative prefix for note TREE as a string."
   (cond ((dime-note-tree--leaf-p tree) "-- ")
-	((dime-note-tree--collapsed-p tree) "[+] ")
-	(t "-+  ")))
+        ((dime-note-tree--collapsed-p tree) "[+] ")
+        (t "-+  ")))
 
 (defun dime-note-tree--insert-list (list prefix)
   "Insert LIST of note trees using PREFIX for each."
   (loop for (elt . rest) on list
-	do (cond (rest
-		  (insert prefix " |")
-		  (dime-note-tree--insert elt (concat prefix " |"))
+        do (cond (rest
+                  (insert prefix " |")
+                  (dime-note-tree--insert elt (concat prefix " |"))
                   (insert "\n"))
-		 (t
-		  (insert prefix " `")
-		  (dime-note-tree--insert elt (concat prefix "  "))))))
+                 (t
+                  (insert prefix " `")
+                  (dime-note-tree--insert elt (concat prefix "  "))))))
 
 (defun dime-note-tree--indent-item (start end prefix)
   "Insert PREFIX at the beginning of each line except the first.

--- a/dime-note-tree.el
+++ b/dime-note-tree.el
@@ -169,7 +169,8 @@ are the region to modify."
 
 (defun dime-note-tree--insert (tree prefix)
   "Insert TREE prefixed with PREFIX at point."
-  (with-struct (dime-note-tree-- print-fn kids collapsed-p start-mark end-mark)
+  (dime--with-struct (dime-note-tree--
+                      print-fn kids collapsed-p start-mark end-mark)
       tree
     (let ((line-start (line-beginning-position)))
       (setf start-mark (point-marker))
@@ -196,7 +197,9 @@ are the region to modify."
 
 (defun dime-note-tree--toggle (tree)
   "Toggle the visibility of TREE's children."
-  (with-struct (dime-note-tree-- collapsed-p start-mark end-mark prefix) tree
+  (dime--with-struct (dime-note-tree--
+                      collapsed-p start-mark end-mark prefix)
+      tree
     (setf collapsed-p (not collapsed-p))
     (dime-note-tree--delete tree)
     (insert-before-markers " ") ; move parent's end-mark

--- a/dime-repl.el
+++ b/dime-repl.el
@@ -474,7 +474,8 @@ This is automatically synchronized from Dylan.")
       (dime-repl-save-marker dime-repl-output-start
         (dime-repl-save-marker dime-repl-output-end
           (goto-char dime-repl-output-end)
-          (insert-before-markers (format "; Evaluation aborted on %s.\n" condition))
+          (insert-before-markers
+           (format "; Evaluation aborted on %s.\n" condition))
           (dime-repl-insert-prompt))))
     (dime-repl-show-maximum-output)))
 
@@ -491,7 +492,8 @@ Return the position of the prompt beginning."
         (dime-propertize-region
             '(face dime-repl-prompt-face read-only t intangible t
                    dime-repl-prompt t
-                   rear-nonsticky (dime-repl-prompt read-only face intangible))
+                   rear-nonsticky
+                   (dime-repl-prompt read-only face intangible))
           (insert-before-markers prompt))
         (set-marker dime-repl-prompt-start-mark prompt-start)
         prompt-start))))
@@ -1012,7 +1014,8 @@ truncated.  That part is untested, though!"
         (hist (or history dime-repl-input-history)))
     (unless (file-writable-p file)
       (error (format "History file not writable: %s" file)))
-    (let ((hist (cl-subseq hist 0 (min (length hist) dime-repl-history-size))))
+    (let ((hist (cl-subseq hist 0 (min (length hist)
+                                       dime-repl-history-size))))
       ;;(message "saving %s to %s\n" hist file)
       (with-temp-file file
         (let ((cs dime-repl-history-file-coding-system)
@@ -1021,7 +1024,8 @@ truncated.  That part is untested, though!"
           (insert (format ";; -*- coding: %s -*-\n" cs))
           (insert ";; History for DIME REPL. Automatically written.\n"
                   ";; Edit only if you know what you're doing\n")
-          (prin1 (mapcar #'substring-no-properties hist) (current-buffer)))))))
+          (prin1 (mapcar #'substring-no-properties hist)
+                 (current-buffer)))))))
 
 (defun dime-repl-save-all-histories ()
   "Save the history in each repl buffer."
@@ -1088,7 +1092,8 @@ The handler will use qeuery to ask the use if the error should be ingored."
 
 (defun dime-repl-read-break ()
   (interactive)
-  (dime-dispatch-event `(:emacs-interrupt ,(car dime-repl-read-string-threads))))
+  (dime-dispatch-event
+   `(:emacs-interrupt ,(car dime-repl-read-string-threads))))
 
 (defun dime-repl-abort-read (_thread _tag)
   (with-current-buffer (dime-repl-output-buffer)
@@ -1154,7 +1159,8 @@ of the shortcut \(`:handler'\), and a help text \(`:one-liner'\)."
                           ,@(apply #'append options))))
        (setq dime-repl-shortcut-table
              (cl-remove-if (lambda (s)
-                             (member ',(car names) (dime-repl-shortcut.names s)))
+                             (member ',(car names)
+                                     (dime-repl-shortcut.names s)))
                            dime-repl-shortcut-table))
        (push new-shortcut dime-repl-shortcut-table)
        ',edylan-name)))
@@ -1240,7 +1246,8 @@ expansion will be added to the REPL's history.)"
                  (pop dime-repl-directory-stack)))))
   (:one-liner "Restore the last saved directory."))
 
-(define-dime-repl-shortcut nil ("change-project" "change-package" "!p" "in-project" "in")
+(define-dime-repl-shortcut nil
+  ("change-project" "change-package" "!p" "in-project" "in")
   (:handler 'dime-repl-set-project)
   (:one-liner "Change the current project."))
 
@@ -1303,7 +1310,8 @@ expansion will be added to the REPL's history.)"
               (dime-repl-send-input t)))
   (:one-liner "Define a new global, special, variable."))
 
-(define-dime-repl-shortcut dime-repl-compile-and-load ("compile-and-load" "cl")
+(define-dime-repl-shortcut dime-repl-compile-and-load
+  ("compile-and-load" "cl")
   (:handler (lambda (filename)
               (interactive (list (expand-file-name
                                   (read-file-name "File: " nil nil nil nil))))

--- a/dime-repl.el
+++ b/dime-repl.el
@@ -287,7 +287,7 @@ See `dime-repl-output-target-to-marker'."
           (insert-before-markers string)
           (set-marker marker (point)))))))
 
-(defun dime-switch-to-output-buffer ()
+(defun dime-repl-switch-to-output-buffer ()
   "Select the output buffer, when possible in an existing window.
 
 Hint: You can use `display-buffer-reuse-frames' and
@@ -362,7 +362,7 @@ This is automatically synchronized from Dylan.")
     map))
 
 (dime-define-keys dime-prefix-map
-  ("\C-z" 'dime-switch-to-output-buffer)
+  ("\C-z" 'dime-repl-switch-to-output-buffer)
   ("\M-p" 'dime-repl-set-project))
 
 (dime-define-keys dime-mode-map
@@ -452,7 +452,7 @@ This is automatically synchronized from Dylan.")
 
 (defun dime-repl ()
   (interactive)
-  (dime-switch-to-output-buffer))
+  (dime-repl-switch-to-output-buffer))
 
 (defun dime-repl-mode-beginning-of-defun (&optional arg)
   (if (and arg (< arg 0))
@@ -1095,7 +1095,7 @@ The handler will use qeuery to ask the use if the error should be ingored."
 (defvar-local dime-repl-read-string-tags nil)
 
 (defun dime-repl-read-string (thread tag)
-  (dime-switch-to-output-buffer)
+  (dime-repl-switch-to-output-buffer)
   (push thread dime-repl-read-string-threads)
   (push tag dime-repl-read-string-tags)
   (goto-char (point-max))
@@ -1391,7 +1391,7 @@ expansion will be added to the REPL's history.)"
   (interactive)
   (let ((call (dime-eval `(swank-backend::frame-call
                            ,(dime-debug-frame-number-at-point)))))
-    (dime-switch-to-output-buffer)
+    (dime-repl-switch-to-output-buffer)
     (if (>= (point) dime-repl-prompt-start-mark)
         (insert call)
       (save-excursion

--- a/dime-repl.el
+++ b/dime-repl.el
@@ -153,6 +153,16 @@ maintain."
                     (dime-repl-insert-prompt))
                   (current-buffer)))))))
 
+(defun dime-repl-target-to-marker (target)
+  (cl-case target
+    ((nil)
+     (with-current-buffer (dime-repl-output-buffer)
+       dime-repl-output-end))
+    (:repl-result
+     (with-current-buffer (dime-repl-output-buffer)
+       dime-repl-input-start-mark))
+    (t nil)))
+
 (defvar dime-repl-banner-function 'dime-repl-insert-banner)
 
 (defun dime-repl-update-banner ()
@@ -1461,6 +1471,7 @@ expansion will be added to the REPL's history.)"
   (remove-hook 'dime-event-hooks 'dime-repl-event-hook-function)
   (remove-hook 'dime-connected-hook 'dime-repl-connected-hook-function))
 
+(setq dime-output-target-to-marker-function 'dime-repl-target-to-marker)
 (add-hook 'dime-repl-mode-hook 'dime-repl-add-easy-menu)
 (add-hook 'dime-sync-project-and-directory-hook
           'dime-repl-sync-project-and-directory)

--- a/dime-repl.el
+++ b/dime-repl.el
@@ -205,16 +205,6 @@ maintain."
     (run-hook-with-args 'dime-open-stream-hooks stream)
     stream))
 
-(defvar dime-repl-write-string-function 'dime-repl-write-string)
-
-(defun dime-write-string (string &optional target)
-  "Insert STRING in the REPL buffer or some other TARGET.
-If TARGET is nil, insert STRING as regular process
-output.  If TARGET is :repl-result, insert STRING as the result of the
-evaluation.  Other values of TARGET map to an Emacs marker via the
-hashtable `dime-repl-output-target-to-marker'; output is inserted at this marker."
-  (funcall dime-repl-write-string-function string target))
-
 (defun dime-repl-write-string (string &optional target)
   (cl-case target
     ((nil) (dime-repl-emit string))
@@ -437,6 +427,7 @@ This is automatically synchronized from Dylan.")
   (setq font-lock-defaults nil)
   (setq mode-name "REPL")
   (setq dime-current-thread :repl-thread)
+  (setq dime-write-string-function 'dime-repl-write-string)
   (set (make-local-variable 'scroll-conservatively) 20)
   (set (make-local-variable 'scroll-margin) 0)
   (when dime-repl-history-file

--- a/dime-repl.el
+++ b/dime-repl.el
@@ -414,7 +414,7 @@ This is automatically synchronized from Dylan.")
 (dime-define-keys dime-debug-mode-map
   ("\C-y" 'dime-repl-insert-debug-frame-call-to-repl))
 
-(def-dime-selector-method ?r
+(define-dime-selector-method ?r
   "DIME Read-Eval-Print-Loop."
   (dime-repl-output-buffer))
 
@@ -466,19 +466,18 @@ This is automatically synchronized from Dylan.")
 (defun dime-repl-mode-beginning-of-defun (&optional arg)
   (if (and arg (< arg 0))
       (dime-repl-mode-end-of-defun (- arg))
-      (dotimes (i (or arg 1))
+      (dotimes (_i (or arg 1))
         (dime-repl-previous-prompt))))
 
 (defun dime-repl-mode-end-of-defun (&optional arg)
   (if (and arg (< arg 0))
       (dime-repl-mode-beginning-of-defun (- arg))
-      (dotimes (i (or arg 1))
+      (dotimes (_i (or arg 1))
         (dime-repl-next-prompt))))
 
-(defun dime-repl-send-string (string &optional command-string)
-  (cond (dime-repl-read-mode
-         (dime-repl-return-string string))
-        (t (dime-repl-eval-string string))))
+(defun dime-repl-send-string (string &optional _command-string)
+  (if dime-repl-read-mode (dime-repl-return-string string)
+    (dime-repl-eval-string string)))
 
 (defun dime-repl-eval-string (string)
   (dime-rex ()
@@ -1123,7 +1122,7 @@ The handler will use qeuery to ask the use if the error should be ingored."
   (interactive)
   (dime-dispatch-event `(:emacs-interrupt ,(car dime-repl-read-string-threads))))
 
-(defun dime-repl-abort-read (thread tag)
+(defun dime-repl-abort-read (_thread _tag)
   (with-current-buffer (dime-repl-output-buffer)
     (pop dime-repl-read-string-threads)
     (pop dime-repl-read-string-tags)
@@ -1133,7 +1132,7 @@ The handler will use qeuery to ask the use if the error should be ingored."
 
 ;;;;; REPL handlers
 
-(defstruct (dime-repl-shortcut (:conc-name dime-repl-shortcut.))
+(cl-defstruct (dime-repl-shortcut (:conc-name dime-repl-shortcut.))
   symbol names handler one-liner)
 
 (defvar dime-repl-shortcut-table nil
@@ -1490,7 +1489,7 @@ expansion will be added to the REPL's history.)"
            (goto-char (point-max))))))
 
 (defun dime-repl-connected-hook-function ()
-  (cl-destructuring-bind (project prompt)
+  (cl-destructuring-bind (_project prompt)
       (let ((dime-current-thread t))
 	(dime-eval '(swank:create-repl nil)))
     (setf (dime-dylan-project-prompt-string) prompt))

--- a/dime-repl.el
+++ b/dime-repl.el
@@ -165,7 +165,7 @@ maintain."
 (defun dime-repl-insert-banner ()
   (when (zerop (buffer-size))
     (let ((welcome (concat "; DIME " (or (dime-changelog-date)
-                                          "- ChangeLog file not found"))))
+                                         "- ChangeLog file not found"))))
       (insert welcome))))
 
 (defun dime-repl-init-output-buffer (connection)
@@ -195,7 +195,7 @@ maintain."
   (let ((stream (open-network-stream "*dylan-output-stream*"
                                      (dime-with-connection-buffer ()
                                        (current-buffer))
-				     dime-dylan-host port)))
+                                     dime-dylan-host port)))
     (dime-set-query-on-exit-flag stream)
     (set-process-filter stream 'dime-repl-output-filter)
     (let ((pcs (process-coding-system (dime-current-connection))))
@@ -228,9 +228,9 @@ This is set to nil after displaying the buffer.")
 (defmacro dime-repl-save-marker (marker &rest body)
   (declare (indent 1))
   (let ((pos (cl-gensym "pos")))
-  `(let ((,pos (marker-position ,marker)))
-     (prog1 (progn . ,body)
-       (set-marker ,marker ,pos)))))
+    `(let ((,pos (marker-position ,marker)))
+       (prog1 (progn . ,body)
+         (set-marker ,marker ,pos)))))
 
 (defun dime-repl-emit (string)
   ;; insert the string STRING in the output buffer
@@ -239,7 +239,7 @@ This is set to nil after displaying the buffer.")
       (goto-char dime-repl-output-end)
       (dime-repl-save-marker dime-repl-output-start
         (dime-propertize-region '(face dime-repl-output-face
-                                        rear-nonsticky (face))
+                                       rear-nonsticky (face))
           (insert-before-markers string)
           (when (and (= (point) dime-repl-prompt-start-mark)
                      (not (bolp)))
@@ -259,7 +259,7 @@ This is set to nil after displaying the buffer.")
           (goto-char dime-repl-input-start-mark)
           (when (and bol (not (bolp))) (insert-before-markers "\n"))
           (dime-propertize-region `(face dime-repl-result-face
-                                          rear-nonsticky (face))
+                                         rear-nonsticky (face))
             (insert-before-markers string)))))
     (dime-repl-show-maximum-output)))
 
@@ -397,7 +397,7 @@ This is automatically synchronized from Dylan.")
   ("\M-r" 'dime-repl-previous-matching-input)
   ("\M-s" 'dime-repl-next-matching-input)
   ("\C-c\C-c" 'dime-interrupt)
-  ;("\t"   'dime-complete-symbol)
+  ;; ("\t"   'dime-complete-symbol)
   ("\t"   'dime-indent-and-complete-symbol)
   ("\M-\t" 'dime-complete-symbol)
   (" "    'dime-space)
@@ -466,14 +466,14 @@ This is automatically synchronized from Dylan.")
 (defun dime-repl-mode-beginning-of-defun (&optional arg)
   (if (and arg (< arg 0))
       (dime-repl-mode-end-of-defun (- arg))
-      (dotimes (_i (or arg 1))
-        (dime-repl-previous-prompt))))
+    (dotimes (_i (or arg 1))
+      (dime-repl-previous-prompt))))
 
 (defun dime-repl-mode-end-of-defun (&optional arg)
   (if (and arg (< arg 0))
       (dime-repl-mode-beginning-of-defun (- arg))
-      (dotimes (_i (or arg 1))
-        (dime-repl-next-prompt))))
+    (dotimes (_i (or arg 1))
+      (dime-repl-next-prompt))))
 
 (defun dime-repl-send-string (string &optional _command-string)
   (if dime-repl-read-mode (dime-repl-return-string string)
@@ -481,7 +481,7 @@ This is automatically synchronized from Dylan.")
 
 (defun dime-repl-eval-string (string)
   (dime-rex ()
-      ((list 'swank:listener-eval string) (dime-current-project))
+    ((list 'swank:listener-eval string) (dime-current-project))
     ((:ok result)
      (dime-repl-insert-result result))
     ((:abort condition)
@@ -534,7 +534,7 @@ Return the position of the prompt beginning."
   (when (eobp)
     (let ((win (if (eq (window-buffer) (current-buffer))
                    (selected-window)
-                   (get-buffer-window (current-buffer) t))))
+                 (get-buffer-window (current-buffer) t))))
       (when win
         (with-selected-window win
           (set-window-point win (point-max))
@@ -582,7 +582,7 @@ buffer."
         (t (beginning-of-line 1))))
 
 (defun dime-repl-in-input-area-p ()
-   (<= dime-repl-input-start-mark (point)))
+  (<= dime-repl-input-start-mark (point)))
 
 (defun dime-repl-at-prompt-start-p ()
   ;; This will not work on non-current prompts.
@@ -634,10 +634,10 @@ buffer."
 (defun dime-repl-search-property-change (prop &optional backward)
   (cond (backward
          (goto-char (or (previous-single-char-property-change (point) prop)
-			(point-min))))
+                        (point-min))))
         (t
          (goto-char (or (next-single-char-property-change (point) prop)
-			(point-max))))))
+                        (point-max))))))
 
 (defun dime-repl-end-of-proprange-p (property)
   (and (get-char-property (max 1 (1- (point))) property)
@@ -834,14 +834,15 @@ earlier in the buffer."
 
 ;; TODO: Use the standard `string-trim' function from `subr-x'?
 (defun dime-repl-string-trim (character-bag string)
-  (cl-flet ((find-bound (&optional from-end)
-           (cl-position-if-not (lambda (char) (memq char character-bag))
-                            string :from-end from-end)))
+  (cl-flet ((find-bound
+             (&optional from-end)
+             (cl-position-if-not (lambda (char) (memq char character-bag))
+                                 string :from-end from-end)))
     (let ((start (find-bound))
           (end (find-bound t)))
       (if start
           (cl-subseq string start (1+ end))
-          ""))))
+        ""))))
 
 (defun dime-repl-add-to-input-history (string)
   "Add STRING to the input history.
@@ -876,7 +877,7 @@ If REGEXP is non-nil, only lines matching REGEXP are considered."
                       dime-repl-input-history-position)
                      (t min-pos)))
          (pos (dime-repl-position-in-history pos0 direction (or regexp "")
-                                              (dime-repl-current-input)))
+                                             (dime-repl-current-input)))
          (msg nil))
     (cond ((and (< min-pos pos) (< pos max-pos))
            (dime-repl-replace-input (nth pos dime-repl-input-history))
@@ -903,7 +904,7 @@ If REGEXP is non-nil, only lines matching REGEXP are considered."
   (setq last-command this-command))
 
 (defun dime-repl-position-in-history (start-pos direction regexp
-                                       &optional exclude-string)
+                                                &optional exclude-string)
   "Return the position of the history item matching REGEXP.
 Return -1 resp. the length of the history if no item matches.
 If EXCLUDE-STRING is specified then it's excluded from the search."
@@ -947,13 +948,13 @@ See `dime-repl-previous-input'."
 
 (defun dime-repl-previous-matching-input (regexp)
   (interactive (list (dime-read-from-minibuffer
-		      "Previous element matching (regexp): ")))
+                      "Previous element matching (regexp): ")))
   (dime-repl-terminate-history-search)
   (dime-repl-history-replace 'backward regexp))
 
 (defun dime-repl-next-matching-input (regexp)
   (interactive (list (dime-read-from-minibuffer
-		      "Next element matching (regexp): ")))
+                      "Next element matching (regexp): ")))
   (dime-repl-terminate-history-search)
   (dime-repl-history-replace 'forward regexp))
 
@@ -977,7 +978,7 @@ history entries while navigating the repl history."
   (interactive (list (dime-repl-current-input)))
   (let ((merged-history
          (dime-repl-merge-histories dime-repl-input-history
-                                     (dime-repl-read-history nil t))))
+                                    (dime-repl-read-history nil t))))
     (setq dime-repl-input-history
           (cl-delete string merged-history :test #'string=))
     (dime-repl-save-history))
@@ -1028,7 +1029,7 @@ current history in that it tries to detect the unique entries using
   (let ((file (or filename dime-repl-history-file)))
     (with-temp-message "saving history..."
       (let ((hist (dime-repl-merge-histories (dime-repl-read-history file t)
-                                              dime-repl-input-history)))
+                                             dime-repl-input-history)))
         (dime-repl-save-history file hist)))))
 
 (defun dime-repl-save-history (&optional filename history)
@@ -1113,9 +1114,9 @@ The handler will use qeuery to ask the use if the error should be ingored."
 
 (defun dime-repl-return-string (string)
   (dime-dispatch-event `(:emacs-return-string
-                          ,(pop dime-repl-read-string-threads)
-                          ,(pop dime-repl-read-string-tags)
-                          ,string))
+                         ,(pop dime-repl-read-string-threads)
+                         ,(pop dime-repl-read-string-tags)
+                         ,string))
   (dime-repl-read-mode -1))
 
 (defun dime-repl-read-break ()
@@ -1148,15 +1149,15 @@ The handler will use qeuery to ask the use if the error should be ingored."
   (interactive)
   (if (> (point) dime-repl-input-start-mark)
       (insert (string dime-repl-shortcut-dispatch-char))
-      (let ((shortcut (dime-repl-lookup-shortcut
-                       (completing-read "Command: "
-                                        (dime-bogus-completion-alist
-                                         (dime-repl-list-all-shortcuts))
-                                        nil t nil
-                                        'dime-repl-shortcut-history))))
-        (dime--with-struct (dime-repl-shortcut. handler) shortcut
-          (let ((dime-repl-within-shortcut-handler-p t))
-            (call-interactively handler))))))
+    (let ((shortcut (dime-repl-lookup-shortcut
+                     (completing-read "Command: "
+                                      (dime-bogus-completion-alist
+                                       (dime-repl-list-all-shortcuts))
+                                      nil t nil
+                                      'dime-repl-shortcut-history))))
+      (dime--with-struct (dime-repl-shortcut. handler) shortcut
+        (let ((dime-repl-within-shortcut-handler-p t))
+          (call-interactively handler))))))
 
 (defun dime-repl-list-all-shortcuts ()
   (loop for shortcut in dime-repl-shortcut-table
@@ -1164,7 +1165,7 @@ The handler will use qeuery to ask the use if the error should be ingored."
 
 (defun dime-repl-lookup-shortcut (name)
   (cl-find-if (lambda (s) (member name (dime-repl-shortcut.names s)))
-           dime-repl-shortcut-table))
+              dime-repl-shortcut-table))
 
 (defmacro define-dime-repl-shortcut (edylan-name names &rest options)
   "Define a new repl shortcut. EDYLAN-NAME is a symbol specifying
@@ -1186,8 +1187,8 @@ of the shortcut \(`:handler'\), and a help text \(`:one-liner'\)."
                           ,@(apply #'append options))))
        (setq dime-repl-shortcut-table
              (cl-remove-if (lambda (s)
-                          (member ',(car names) (dime-repl-shortcut.names s)))
-                        dime-repl-shortcut-table))
+                             (member ',(car names) (dime-repl-shortcut.names s)))
+                           dime-repl-shortcut-table))
        (push new-shortcut dime-repl-shortcut-table)
        ',edylan-name)))
 
@@ -1211,8 +1212,8 @@ expansion will be added to the REPL's history.)"
   (interactive)
   (dime-with-popup-buffer ((dime-buffer-name :repl-help))
     (let ((table (cl-sort (cl-copy-list dime-repl-shortcut-table) #'string<
-                        :key (lambda (x)
-                               (car (dime-repl-shortcut.names x))))))
+                          :key (lambda (x)
+                                 (car (dime-repl-shortcut.names x))))))
       (save-excursion
         (dolist (shortcut table)
           (let ((names (dime-repl-shortcut.names shortcut)))
@@ -1232,7 +1233,7 @@ expansion will be added to the REPL's history.)"
       (save-some-buffers nil (lambda ()
                                (and (memq major-mode dime-dylan-modes)
                                     (not (null buffer-file-name)))))
-      (save-some-buffers)))
+    (save-some-buffers)))
 
 (define-dime-repl-shortcut dime-repl-shortcut-help ("help")
   (:handler 'dime-repl-list-shortcuts)
@@ -1250,7 +1251,7 @@ expansion will be added to the REPL's history.)"
   (:one-liner "Show the current directory."))
 
 (define-dime-repl-shortcut dime-repl-push-directory
-    ("push-directory" "+d" "pushd")
+  ("push-directory" "+d" "pushd")
   (:handler (lambda (directory)
               (interactive
                (list (read-directory-name
@@ -1263,13 +1264,13 @@ expansion will be added to the REPL's history.)"
   (:one-liner "Save the current directory and set it to a new one."))
 
 (define-dime-repl-shortcut dime-repl-pop-directory
-    ("pop-directory" "-d" "popd")
+  ("pop-directory" "-d" "popd")
   (:handler (lambda ()
               (interactive)
               (if (null dime-repl-directory-stack)
                   (message "Directory stack is empty.")
-                  (dime-repl-set-default-directory
-                   (pop dime-repl-directory-stack)))))
+                (dime-repl-set-default-directory
+                 (pop dime-repl-directory-stack)))))
   (:one-liner "Restore the last saved directory."))
 
 (define-dime-repl-shortcut nil ("change-project" "change-package" "!p" "in-project" "in")
@@ -1288,8 +1289,8 @@ expansion will be added to the REPL's history.)"
               (interactive)
               (if (null dime-repl-project-stack)
                   (message "Project stack is empty.")
-                  (dime-repl-set-project
-                   (pop dime-repl-project-stack)))))
+                (dime-repl-set-project
+                 (pop dime-repl-project-stack)))))
   (:one-liner "Restore the last saved project."))
 
 (define-dime-repl-shortcut dime-repl-resend ("resend-form")
@@ -1318,7 +1319,7 @@ expansion will be added to the REPL's history.)"
 
 (define-dime-repl-shortcut dime-repl-quit ("quit")
   (:handler (lambda ()
-	      (interactive)
+              (interactive)
               ;; `dime-quit-dylan' determines the connection to quit
               ;; on behalf of the REPL's `dime-buffer-connection'.
               (let ((repl-buffer (dime-repl-output-buffer)))
@@ -1356,10 +1357,10 @@ expansion will be added to the REPL's history.)"
   (let ((proc (dime-inferior-process)))
     (cond (proc
            (let ((filter (dime-rcurry #'dime-repl-inferior-output-filter
-                                       (dime-current-connection))))
+                                      (dime-current-connection))))
              (set-process-filter proc filter)))
-	  (noerror)
-	  (t (error "No inferior dylan process")))))
+          (noerror)
+          (t (error "No inferior dylan process")))))
 
 (defun dime-repl-inferior-output-filter (proc string conn)
   (cond ((eq (process-status conn) 'closed)
@@ -1388,23 +1389,23 @@ expansion will be added to the REPL's history.)"
     (pop-to-buffer buffer)))
 
 (defun dime-repl-inspector-copy-down-to-repl (number)
-   "Evaluate the inspector slot at point via the REPL (to set `*')."
-   (interactive (list (or (get-text-property (point) 'dime-part-number)
-                          (error "No part at point"))))
-   (dime-repl-send-string (format "%s" `(swank:inspector-nth-part ,number)))
-   (dime-repl))
+  "Evaluate the inspector slot at point via the REPL (to set `*')."
+  (interactive (list (or (get-text-property (point) 'dime-part-number)
+                         (error "No part at point"))))
+  (dime-repl-send-string (format "%s" `(swank:inspector-nth-part ,number)))
+  (dime-repl))
 
 (defun dime-repl-insert-debug-frame-call-to-repl ()
   "Insert a call to a frame at point."
   (interactive)
   (let ((call (dime-eval `(swank-backend::frame-call
-                            ,(dime-debug-frame-number-at-point)))))
+                           ,(dime-debug-frame-number-at-point)))))
     (dime-switch-to-output-buffer)
     (if (>= (point) dime-repl-prompt-start-mark)
         (insert call)
-	(save-excursion
-	  (goto-char (point-max))
-	  (insert call))))
+      (save-excursion
+        (goto-char (point-max))
+        (insert call))))
   (dime-repl))
 
 (defun dime-repl-set-default-directory (directory)
@@ -1414,7 +1415,7 @@ expansion will be added to the REPL's history.)"
     (message "default-directory: %s"
              (dime-from-dylan-filename
               (dime-repl-shortcut-eval `(swank:set-default-directory
-                                          ,(dime-to-dylan-filename dir)))))
+                                         ,(dime-to-dylan-filename dir)))))
     (with-current-buffer (dime-repl-output-buffer)
       (setq default-directory dir))))
 
@@ -1491,7 +1492,7 @@ expansion will be added to the REPL's history.)"
 (defun dime-repl-connected-hook-function ()
   (cl-destructuring-bind (_project prompt)
       (let ((dime-current-thread t))
-	(dime-eval '(swank:create-repl nil)))
+        (dime-eval '(swank:create-repl nil)))
     (setf (dime-dylan-project-prompt-string) prompt))
   (dime-repl-hide-inferior-dylan-buffer)
   (dime-repl-init-output-buffer (dime-connection)))
@@ -1515,8 +1516,8 @@ expansion will be added to the REPL's history.)"
      (setf (dime-dylan-project-prompt-string) prompt-string)
      (let ((buffer (dime-connection-output-buffer)))
        (when (buffer-live-p buffer)
-	 (with-current-buffer buffer
-	   (setq dime-buffer-project project))))
+         (with-current-buffer buffer
+           (setq dime-buffer-project project))))
      t)
     (t nil)))
 

--- a/dime-repl.el
+++ b/dime-repl.el
@@ -759,14 +759,14 @@ earlier in the buffer."
   (interactive (list (let* ((p (dime-current-project)))
                        (dime-read-project-name "Project: " p))))
   (with-current-buffer (dime-repl-output-buffer)
-    (let ((previouse-point (- (point) dime-repl-input-start-mark)))
+    (let ((previous-point (- (point) dime-repl-input-start-mark)))
       (cl-destructuring-bind (name prompt-string)
           (dime-repl-shortcut-eval `(swank:set-package ,project))
         (setf (dime-dylan-project-prompt-string) prompt-string)
         (setf dime-buffer-project name)
         (dime-repl-insert-prompt)
-        (when (plusp previouse-point)
-          (goto-char (+ previouse-point dime-repl-input-start-mark)))))))
+        (when (plusp previous-point)
+          (goto-char (+ previous-point dime-repl-input-start-mark)))))))
 
 
 ;;;;; History

--- a/dime-repl.el
+++ b/dime-repl.el
@@ -1154,7 +1154,7 @@ The handler will use qeuery to ask the use if the error should be ingored."
                                          (dime-repl-list-all-shortcuts))
                                         nil t nil
                                         'dime-repl-shortcut-history))))
-        (with-struct (dime-repl-shortcut. handler) shortcut
+        (dime--with-struct (dime-repl-shortcut. handler) shortcut
           (let ((dime-repl-within-shortcut-handler-p t))
             (call-interactively handler))))))
 

--- a/dime-repl.el
+++ b/dime-repl.el
@@ -1005,15 +1005,16 @@ from a user defined filename."
   (let ((file (or filename dime-repl-history-file)))
     (setq dime-repl-input-history (dime-repl-read-history file t))))
 
-(defun dime-repl-read-history (&optional filename noerrer)
+(defun dime-repl-read-history (&optional filename noerror)
   "Read and return the history from FILENAME.
+
 The default value for FILENAME is `dime-repl-history-file'.
-If NOERROR is true return and the file doesn't exits return nil."
-  (let ((file (or filename dime-repl-history-file)))
-    (cond ((not (file-readable-p file)) '())
-          (t (with-temp-buffer
-               (insert-file-contents file)
-               (read (current-buffer)))))))
+If NOERROR is non-nil and the file is not readable return nil."
+  (let ((filename (or filename dime-repl-history-file)))
+    (unless (and noerror (not (file-readable-p filename)))
+      (with-temp-buffer
+        (insert-file-contents filename)
+        (read (current-buffer))))))
 
 (defun dime-repl-read-history-filename ()
   (read-file-name "Use DIME REPL history from file: "

--- a/dime.el
+++ b/dime.el
@@ -5456,6 +5456,19 @@ This is 0 if START and END at the same line."
   (- (count-lines start end)
      (if (save-excursion (goto-char end) (bolp)) 0 1)))
 
+(defvar-local dime-write-string-function nil)
+
+(defun dime-write-string (string &optional target)
+  "Insert STRING in the REPL buffer or some other TARGET.
+
+If TARGET is nil, insert STRING as regular process
+output.  If TARGET is :repl-result, insert STRING as the result of the
+evaluation.  Other values of TARGET map to an Emacs marker via the
+hashtable `dime-repl-output-target-to-marker'; output is inserted at this marker."
+  (unless dime-write-string-function
+    (user-error "dime-write-string-function not set"))
+  (funcall dime-write-string-function string target))
+
 
 ;;;;; Dime debug commands
 

--- a/dime.el
+++ b/dime.el
@@ -392,28 +392,28 @@ Dime: Dylan interaction mode for Emacs (minor-mode).
 
 Commands to compile the current buffer's source file and visually
 highlight any resulting compiler notes and warnings:
-\\[dime-compile-and-load-file]	- Compile and load the current buffer's file.
-\\[dime-compile-file]	- Compile (but not load) the current buffer's file.
-\\[dime-compile-defun]	- Compile the top-level form at point.
+\\[dime-compile-and-load-file]  - Compile and load the current buffer's file.
+\\[dime-compile-file]   - Compile (but not load) the current buffer's file.
+\\[dime-compile-defun]  - Compile the top-level form at point.
 
 Commands for visiting compiler notes:
-\\[dime-next-note]	- Goto the next form with a compiler note.
-\\[dime-previous-note]	- Goto the previous form with a compiler note.
-\\[dime-remove-notes]	- Remove compiler-note annotations in buffer.
+\\[dime-next-note]      - Goto the next form with a compiler note.
+\\[dime-previous-note]  - Goto the previous form with a compiler note.
+\\[dime-remove-notes]   - Remove compiler-note annotations in buffer.
 
 Finding definitions:
-\\[dime-edit-definition]	- Edit the definition of the function called at point.
-\\[dime-pop-find-definition-stack]	- Pop the definition stack to go back from a definition.
+\\[dime-edit-definition]        - Edit the definition of the function called at point.
+\\[dime-pop-find-definition-stack]      - Pop the definition stack to go back from a definition.
 
 Documentation commands:
-\\[dime-describe-symbol]	- Describe symbol.
-\\[dime-apropos]	- Apropos search.
-\\[dime-disassemble-symbol]	- Disassemble a function.
+\\[dime-describe-symbol]        - Describe symbol.
+\\[dime-apropos]        - Apropos search.
+\\[dime-disassemble-symbol]     - Disassemble a function.
 
 Evaluation commands:
-\\[dime-eval-defun]	- Evaluate top-level from containing point.
-\\[dime-eval-last-expression]	- Evaluate sexp before point.
-\\[dime-pprint-eval-last-expression]	- Evaluate sexp before point, pretty-print result.
+\\[dime-eval-defun]     - Evaluate top-level from containing point.
+\\[dime-eval-last-expression]   - Evaluate sexp before point.
+\\[dime-pprint-eval-last-expression]    - Evaluate sexp before point, pretty-print result.
 
 Full set of commands:
 \\{dime-mode-map}"
@@ -471,12 +471,12 @@ information."
     ("\M-,"      dime-pop-find-definition-stack)
     ("\M-_"      dime-edit-uses)    ; for German layout
     ("\M-?"      dime-edit-uses)    ; for USian layout
-    ("\C-x4." 	 dime-edit-definition-other-window)
-    ("\C-x5." 	 dime-edit-definition-other-frame)
+    ("\C-x4."    dime-edit-definition-other-window)
+    ("\C-x5."    dime-edit-definition-other-frame)
     ("\C-x\C-e"  dime-eval-last-expression)
     ("\C-\M-x"   dime-eval-defun)
     ;; Include PREFIX keys...
-    ("\C-c"	 dime-prefix-map)))
+    ("\C-c"      dime-prefix-map)))
 
 (defvar dime-prefix-map nil
   "Keymap for commands prefixed with `dime-prefix-key'.")
@@ -644,28 +644,28 @@ VALUE. If one is found, the BODY is executed with ARGS bound to the
 corresponding values in the CDR of VALUE."
   (declare (indent 1))
   (let ((operator (cl-gensym "op-"))
-	(operands (cl-gensym "rand-"))
-	(tmp (cl-gensym "tmp-")))
+        (operands (cl-gensym "rand-"))
+        (tmp (cl-gensym "tmp-")))
     `(let* ((,tmp ,value)
-	    (,operator (car ,tmp))
-	    (,operands (cdr ,tmp)))
+            (,operator (car ,tmp))
+            (,operands (cdr ,tmp)))
        (cl-case ,operator
-	 ,@(mapcar (lambda (clause)
+         ,@(mapcar (lambda (clause)
                      (if (eq (car clause) t)
                          `(t ,@(cdr clause))
                        (cl-destructuring-bind ((op &rest rands) &rest body) clause
                          `(,op (cl-destructuring-bind ,rands ,operands
                                  . ,body)))))
-		   patterns)
-	 ,@(if (eq (caar (last patterns)) t)
-	       '()
-	     `((t (error "ELISP dime--destructuring-case failed: %S" ,tmp))))))))
+                   patterns)
+         ,@(if (eq (caar (last patterns)) t)
+               '()
+             `((t (error "ELISP dime--destructuring-case failed: %S" ,tmp))))))))
 
 (defmacro dime-define-keys (keymap &rest key-command)
   "Define keys in KEYMAP. Each KEY-COMMAND is a list of (KEY COMMAND)."
   (declare (indent 1))
   `(progn . ,(mapcar (lambda (k-c) `(define-key ,keymap . ,k-c))
-		     key-command)))
+                     key-command)))
 
 (cl-defmacro dime--with-struct ((conc-name &rest slots) struct &body body)
   "Like `with-slots' but works only for structs.
@@ -673,17 +673,17 @@ corresponding values in the CDR of VALUE."
 \(fn (CONC-NAME &rest SLOTS) STRUCT &body BODY)"
   (declare (indent 2))
   (cl-flet ((reader (slot) (intern (concat (symbol-name conc-name)
-					(symbol-name slot)))))
+                                        (symbol-name slot)))))
     (let ((struct-var (cl-gensym "struct")))
       `(let ((,struct-var ,struct))
-	 (symbol-macrolet
-	     ,(mapcar (lambda (slot)
-			(cl-etypecase slot
-			  (symbol `(,slot (,(reader slot) ,struct-var)))
-			  (cons `(,(first slot) (,(reader (second slot))
-						 ,struct-var)))))
-		      slots)
-	   . ,body)))))
+         (symbol-macrolet
+             ,(mapcar (lambda (slot)
+                        (cl-etypecase slot
+                          (symbol `(,slot (,(reader slot) ,struct-var)))
+                          (cons `(,(first slot) (,(reader (second slot))
+                                                 ,struct-var)))))
+                      slots)
+           . ,body)))))
 
 ;;;;; Very-commonly-used functions
 
@@ -738,7 +738,7 @@ It should be used for \"background\" messages such as argument lists."
     (completing-read prompt (dime-bogus-completion-alist
                              (dime-eval
                               `(swank:list-all-package-names t)))
-		     nil t initial-value)))
+                     nil t initial-value)))
 
 ;; Interface
 (defun dime-read-symbol-name (prompt &optional query)
@@ -758,7 +758,7 @@ positions before and after executing BODY."
   (let ((start (cl-gensym)))
     `(let ((,start (point)))
        (prog1 (progn ,@body)
-	 (add-text-properties ,start (point) ,props)))))
+         (add-text-properties ,start (point) ,props)))))
 
 (defun dime-add-face (face string)
   (declare (indent 1))
@@ -1418,9 +1418,9 @@ Return nil if the file doesn't exist or is empty; otherwise the
 first line of the file."
   (condition-case _
       (with-temp-buffer
-	(insert-file-contents "~/.dime-secret")
-	(goto-char (point-min))
-	(buffer-substring (point-min) (line-end-position)))
+        (insert-file-contents "~/.dime-secret")
+        (goto-char (point-min))
+        (buffer-substring (point-min) (line-end-position)))
     (file-error nil)))
 
 ;;; Interface
@@ -2034,7 +2034,7 @@ or nil if nothing suitable can be found.")
   "Evaluate EXPR in Dylan and return the result."
   (let* ((tag (cl-gensym (format "dime-result-%d-"
                                  (1+ (dime-continuation-counter)))))
-	 (dime-stack-eval-tags (cons tag dime-stack-eval-tags)))
+         (dime-stack-eval-tags (cons tag dime-stack-eval-tags)))
     (apply
      #'funcall
      (catch tag
@@ -2287,8 +2287,8 @@ Debugged requests are ignored."
 (defun dime-pprint-event (event buffer)
   "Pretty print EVENT in BUFFER with limited depth and width."
   (let ((print-length 20)
-	(print-level 6)
-	(pp-escape-newlines t))
+        (print-level 6)
+        (pp-escape-newlines t))
     (pp event buffer)))
 
 (defun dime-events-buffer ()
@@ -2834,7 +2834,7 @@ The overlay has several properties:
 The help text describes both notes, and the highest of the severities
 is kept."
   (cl-flet ((putp (name value) (overlay-put overlay name value))
-	 (getp (name)       (overlay-get overlay name)))
+         (getp (name)       (overlay-get overlay name)))
     (putp 'severity (dime-most-severe severity (getp 'severity)))
     (putp 'face (dime-severity-face (getp 'severity)))
     (putp 'help-echo (concat (getp 'help-echo) "\n" message))))
@@ -3154,7 +3154,7 @@ you should check twice before modifying.")
                          qualifiers specializers)))
     (or (and (re-search-forward regexp  nil t)
              (goto-char (match-beginning 0)))
-        ;;	(dime-goto-location-position `(:function-name ,name))
+        ;;      (dime-goto-location-position `(:function-name ,name))
         )))
 
 (defun dime-search-call-site (fname)
@@ -3380,9 +3380,9 @@ more than one space."
   (let ((op (dime-operator-before-point)))
     (when op
       (dime-eval-async `(swank:operator-arglist ,op ,dylan-buffer-module)
-			(lambda (arglist)
-			  (when arglist
-			    (dime-message "%s" arglist)))))))
+                        (lambda (arglist)
+                          (when arglist
+                            (dime-message "%s" arglist)))))))
 
 (defun dime-operator-before-point ()
   (ignore-errors
@@ -3582,7 +3582,7 @@ If INITIAL-VALUE is non-nil, it is inserted into the minibuffer before
 reading input.  The result is a string (\"\" if no input was given)."
   (let ((minibuffer-setup-hook (dime-minibuffer-setup-hook)))
     (read-from-minibuffer prompt initial-value dime-minibuffer-map
-			  nil 'dime-minibuffer-history)))
+                          nil 'dime-minibuffer-history)))
 
 (defun dime-bogus-completion-alist (list)
   "Make an alist out of list.
@@ -4046,7 +4046,7 @@ The value is inserted into a temporary buffer for editing and then set
 in Dylan when committed with \\[dime-edit-value-commit]."
   (interactive
    (list (dime-read-from-minibuffer "Edit value (evaluated): "
-				     (dime-sexp-at-point))))
+                                     (dime-sexp-at-point))))
   (dime-eval-async `(swank:value-for-editing ,form-string)
                     (lexical-let ((form-string form-string)
                                   (project (dime-current-project)))
@@ -4122,8 +4122,8 @@ in Dylan when committed with \\[dime-edit-value-commit]."
 (defun dime-load-file (filename)
   "Load the Dylan file FILENAME."
   (interactive (list
-		(read-file-name "Load file: " nil nil
-				nil (if (buffer-file-name)
+                (read-file-name "Load file: " nil nil
+                                nil (if (buffer-file-name)
                                         (file-name-nondirectory
                                          (buffer-file-name))))))
   (let ((dylan-filename (dime-to-dylan-filename (expand-file-name filename))))
@@ -4346,9 +4346,9 @@ With prefix argument include internal symbols."
   "dime-xref-mode: Major mode for cross-referencing.
 \\<dime-xref-mode-map>\
 The most important commands:
-\\[dime-xref-quit]	- Dismiss buffer.
-\\[dime-show-xref]	- Display referenced source and keep xref window.
-\\[dime-goto-xref]	- Jump to referenced source and dismiss xref window.
+\\[dime-xref-quit]      - Dismiss buffer.
+\\[dime-show-xref]      - Display referenced source and keep xref window.
+\\[dime-goto-xref]      - Jump to referenced source and dismiss xref window.
 
 \\{dime-xref-mode-map}
 \\{dime-popup-buffer-mode-map}
@@ -4946,7 +4946,7 @@ argument is given, with CL:MACROEXPAND."
   "Return STRING propertised with face dime-debug-NAME-face."
   (declare (indent 1))
   (let ((facename (intern (format "dime-debug-%s-face" (symbol-name name))))
-	(var (cl-gensym "string")))
+        (var (cl-gensym "string")))
     `(let ((,var ,string))
       (dime-add-face ',facename ,var)
       ,var)))
@@ -5321,12 +5321,12 @@ Called on the `point-entered' text-property hook."
 (defun dime-debug-frame-number-at-point ()
   (let ((frame (get-text-property (point) 'frame)))
     (cond (frame (car frame))
-	  (t (error "No frame at point")))))
+          (t (error "No frame at point")))))
 
 (defun dime-debug-var-number-at-point ()
   (let ((var (get-text-property (point) 'var)))
     (cond (var var)
-	  (t (error "No variable at point")))))
+          (t (error "No variable at point")))))
 
 (defun dime-debug-previous-frame-number ()
   (save-excursion
@@ -5548,7 +5548,7 @@ See `dime-output-target-to-marker'."
     (save-excursion
       (goto-char pos)
       (let ((fn (get-text-property (point) 'dime-debug-default-action)))
-	(if fn (funcall fn))))))
+        (if fn (funcall fn))))))
 
 (defun dime-debug-cycle ()
   "Cycle between restart list and backtrace."
@@ -5606,7 +5606,7 @@ See `dime-output-target-to-marker'."
 (defun dime-highlight-sexp (&optional start end)
   "Highlight the first sexp after point."
   (let ((start (or start (point)))
-	(end (or end (save-excursion (ignore-errors (forward-sexp)) (point)))))
+        (end (or end (save-excursion (ignore-errors (forward-sexp)) (point)))))
     (dime-flash-region start end)))
 
 (defun dime-highlight-line (&optional timeout)
@@ -5625,7 +5625,7 @@ The details include local variable bindings and CATCH-tags."
   (let ((inhibit-read-only t)
         (inhibit-point-motion-hooks t))
     (if (or on (not (dime-debug-frame-details-visible-p)))
-	(dime-debug-show-frame-details)
+        (dime-debug-show-frame-details)
       (dime-debug-hide-frame-details))))
 
 (defun dime-debug-show-frame-details ()
@@ -5696,7 +5696,7 @@ VAR should be a plist with the keys :name, :id, and :value."
   (let ((frame (dime-debug-frame-number-at-point)))
     (dime-eval-async `(swank:dime-debug-disassemble ,frame)
                       (lambda (result)
-			(dime-show-description result nil)))))
+                        (dime-show-description result nil)))))
 
 
 ;;;;;; Dime debug eval and inspect
@@ -5715,8 +5715,8 @@ VAR should be a plist with the keys :name, :id, and :value."
   (interactive (list (dime-read-from-minibuffer "Eval in frame: ")))
   (let* ((number (dime-debug-frame-number-at-point)))
     (dime-eval-async `(swank:pprint-eval-string-in-frame ,string ,number)
-		      (lambda (result)
-			(dime-show-description result nil)))))
+                      (lambda (result)
+                        (dime-show-description result nil)))))
 
 (defun dime-debug-inspect-in-frame (string)
   "Prompt for an expression and inspect it in the selected frame."
@@ -6249,7 +6249,7 @@ was called originally."
   "Eval an expression and inspect the result."
   (interactive
    (list (dime-read-from-minibuffer "Inspect value (evaluated): "
-				     (dime-sexp-at-point))))
+                                     (dime-sexp-at-point))))
   (dime-eval-async `(swank:init-inspector ,string) 'dime-open-inspector))
 
 (define-derived-mode dime-inspector-mode fundamental-mode
@@ -6415,20 +6415,20 @@ that value.
    `(swank:inspector-pop)
    (lambda (result)
      (cond (result
-	    (dime-open-inspector result (pop dime-inspector-mark-stack)))
-	   (t
-	    (message "No previous object")
-	    (ding))))))
+            (dime-open-inspector result (pop dime-inspector-mark-stack)))
+           (t
+            (message "No previous object")
+            (ding))))))
 
 (defun dime-inspector-next ()
   "Inspect the next object in the history."
   (interactive)
   (let ((result (dime-eval `(swank:inspector-next))))
     (cond (result
-	   (push (dime-inspector-position) dime-inspector-mark-stack)
-	   (dime-open-inspector result))
-	  (t (message "No next object")
-	     (ding)))))
+           (push (dime-inspector-position) dime-inspector-mark-stack)
+           (dime-open-inspector result))
+          (t (message "No next object")
+             (ding)))))
 
 (defun dime-inspector-quit (&optional _kill-buffer)
   "Quit the inspector and kill the buffer."
@@ -7065,9 +7065,9 @@ keys."
   (let ((alist '()))
     (dolist (e list)
       (let* ((k (funcall key e))
-	     (probe (cl-assoc k alist :test test)))
-	(if probe
-	    (push e (cdr probe))
+             (probe (cl-assoc k alist :test test)))
+        (if probe
+            (push e (cdr probe))
             (push (cons k (list e)) alist))))
     ;; Put them back in order.
     (cl-loop for (key . value) in (reverse alist)
@@ -7118,7 +7118,7 @@ keys."
 (defun dime-cl-symbol-name (symbol)
   (let ((n (if (stringp symbol) symbol (symbol-name symbol))))
     (if (string-match ":\\([^:]*\\)$" n)
-	(let ((symbol-part (match-string 1 n)))
+        (let ((symbol-part (match-string 1 n)))
           (if (string-match "^|\\(.*\\)|$" symbol-part)
               (match-string 1 symbol-part)
               symbol-part))
@@ -7127,7 +7127,7 @@ keys."
 (defun dime-cl-symbol-project (symbol &optional default)
   (let ((n (if (stringp symbol) symbol (symbol-name symbol))))
     (if (string-match "^\\([^:]*\\):" n)
-	(match-string 1 n)
+        (match-string 1 n)
       default)))
 
 (defun dime-qualify-cl-symbol-name (symbol-or-name)

--- a/dime.el
+++ b/dime.el
@@ -72,6 +72,21 @@
 (defvar dime-buffer-project nil)
 (defvar dime-buffer-connection nil)
 
+(defvar dime-dispatching-connection nil
+  "Network process currently executing.
+This is dynamically bound while handling messages from Dylan; it
+overrides `dime-buffer-connection' and `dime-default-connection'.")
+
+(defvar-local dime-current-thread t
+   "The id of the current thread on the Dylan side.
+t means the \"current\" thread;
+:repl-thread the thread that executes REPL requests;
+fixnum a specific thread.")
+
+(defvar dime-buffer-project nil
+  "The Dylan project associated with the current buffer.
+This is set only in buffers bound to specific projects.")
+
 (eval-and-compile
   (defvar dime-path
     (let ((path (or (locate-library "dime") load-file-name)))
@@ -1615,11 +1630,6 @@ This is more compatible with the CL reader."
 ;;; they can tie a buffer to a specific connection. The rest takes
 ;;; care of itself.
 
-(defvar dime-dispatching-connection nil
-  "Network process currently executing.
-This is dynamically bound while handling messages from Dylan; it
-overrides `dime-buffer-connection' and `dime-default-connection'.")
-
 (defvar-local dime-buffer-connection nil
   "Network connection to use in the current buffer.
 This overrides `dime-default-connection'.")
@@ -1951,16 +1961,6 @@ Return nil if there's no process object for the connection."
 ;;; particular thread", but can also be used to nominate a specific
 ;;; thread. The REPL and the debugger both use this feature to deal
 ;;; with specific threads.
-
-(defvar-local dime-current-thread t
-   "The id of the current thread on the Dylan side.
-t means the \"current\" thread;
-:repl-thread the thread that executes REPL requests;
-fixnum a specific thread.")
-
-(defvar dime-buffer-project nil
-  "The Dylan project associated with the current buffer.
-This is set only in buffers bound to specific projects.")
 
 ;;; `dime-rex' is the RPC primitive which is used to implement both
 ;;; `dime-eval' and `dime-eval-async'. You can use it directly if

--- a/dime.el
+++ b/dime.el
@@ -5468,6 +5468,20 @@ hashtable `dime-repl-output-target-to-marker'; output is inserted at this marker
     (user-error "dime-write-string-function not set"))
   (funcall dime-write-string-function string target))
 
+(defvar dime-sync-project-and-directory-hook nil
+  "Functions run by dime-sync-project-and-directory.")
+
+(defun dime-sync-project-and-directory ()
+  "Set Dylan's project and directory to the values in current buffer."
+  (interactive)
+  (let* ((project (dime-current-project))
+         (exists-p (or (null project)
+                       (dime-eval
+                        `(cl:packagep (swank::guess-package ,project)))))
+         (directory default-directory))
+    (run-hook-with-args 'dime-sync-project-and-directory-hook
+                        project exists-p directory)))
+
 ;;;; Output target tracking
 
 (defvar dime--last-output-target-id 0
@@ -6886,7 +6900,7 @@ Only considers buffers that are not already visible."
       "--"
       [ "Interrupt Command"        dime-interrupt ,C ]
       [ "Abort Async. Command"     dime-quit ,C ]
-      [ "Sync Project & Directory" dime-sync-project-and-default-directory ,C])))
+      [ "Sync Project & Directory" dime-sync-project-and-directory ,C])))
 
 (defvar dime-debug-easy-menu
   (let ((C '(dime-connected-p)))
@@ -6939,7 +6953,8 @@ Only considers buffers that are not already visible."
                 (dime-compile-defun "Compile current top level form")
                 (dime-interactive-eval "Prompt for form and eval it")
                 (dime-compile-and-load-file "Compile and load current file")
-                (dime-sync-project-and-default-directory "Synch default project and directory with current buffer")
+                (dime-sync-project-and-directory
+                 "Sync default project and directory with current buffer")
                 (dime-next-note "Next compiler note")
                 (dime-previous-note "Previous compiler note")
                 (dime-remove-notes "Remove notes")))

--- a/dime.el
+++ b/dime.el
@@ -5461,7 +5461,7 @@ This is 0 if START and END at the same line."
 If TARGET is nil, insert STRING as regular process
 output.  If TARGET is :repl-result, insert STRING as the result of the
 evaluation.  Other values of TARGET map to an Emacs marker via the
-hashtable `dime-repl-output-target-to-marker'; output is inserted at this marker."
+hashtable `dime-output-target-to-marker'; output is inserted at this marker."
   (unless dime-write-string-function
     (user-error "dime-write-string-function not set"))
   (funcall dime-write-string-function string target))
@@ -5490,17 +5490,14 @@ hashtable `dime-repl-output-target-to-marker'; output is inserted at this marker
   "Map from TARGET ids to Emacs markers.
 The markers indicate where output should be inserted.")
 
+(defvar dime-output-target-to-marker-function nil
+  "Function called by dime--output-target-marker.")
+
 (defun dime--output-target-marker (target)
   "Return the marker where output for TARGET should be inserted."
-  (cl-case target
-    ((nil)
-     (with-current-buffer (dime-repl-output-buffer)
-       dime-repl-output-end))
-    (:repl-result
-     (with-current-buffer (dime-repl-output-buffer)
-       dime-repl-input-start-mark))
-    (t
-     (gethash target dime--output-target-to-marker))))
+  (or (and dime-output-target-to-marker-function
+           (funcall dime-output-target-to-marker-function target))
+      (gethash target dime--output-target-to-marker)))
 
 (defun dime-emit-to-target (string target)
   "Insert STRING at target TARGET.

--- a/dime.el
+++ b/dime.el
@@ -67,7 +67,7 @@
 (require 'thingatpt)
 (require 'timer)
 
-(require 'dylan-mode)
+(require 'dylan)
 
 (defvar dime-buffer-project nil)
 (defvar dime-buffer-connection nil)

--- a/dime.el
+++ b/dime.el
@@ -907,7 +907,6 @@ can restore it later."
   nil
   nil
   '(("q" . dime-popup-buffer-quit-function)
-    ;;("\C-c\C-z" . dime-switch-to-output-buffer)
     ("\M-." . dime-edit-definition)))
 
 (add-to-list 'minor-mode-alist

--- a/dime.el
+++ b/dime.el
@@ -1744,11 +1744,11 @@ the binding for `dime-connection'."
        ;; Accessor
        (defun ,varname (&optional process)
          (dime-with-connection-buffer (process) ,real-var))
-       ;; Setf
-       (defsetf ,varname (&optional process) (store)
+       ;; Setter
+       (gv-define-setter ,varname (store &optional process)
          `(dime-with-connection-buffer (,process)
-            (setq (\, (quote (\, real-var))) (\, store))
-            (\, store)))
+            (setq (\, (quote (\, real-var)))
+                  (\, store))))
        '(\, varname))))
 
 (dime-def-connection-var dime-connection-number nil

--- a/dime.el
+++ b/dime.el
@@ -68,8 +68,6 @@
 (require 'timer)
 
 (require 'dylan-mode)
-(require 'dylan-lid)
-(require 'dylan-opt)
 
 (defvar dime-buffer-project nil)
 (defvar dime-buffer-connection nil)

--- a/dylan-lid.el
+++ b/dylan-lid.el
@@ -1,4 +1,4 @@
-;;; dylan-lid.el --- Major mode for Dylan LID files -*- lexical-binding: t -*-
+;;; dylan-lid.el --- Dylan LID major mode -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2014 Erik Charlebois
 ;; SPDX-License-Identifier: GPL-1.0-or-later

--- a/dylan-mode.el
+++ b/dylan-mode.el
@@ -668,7 +668,7 @@ so we can handle them separately, whether they are well-formed or not."
           (point-max)))))
 
 (defun dylan-backward-find-keyword (&optional match-statement-end in-case no-commas
-                                              start)
+                                              _start)
   "Find the previous keyword.
 
 Move point backward to the beginning of the innermost enclosing
@@ -997,18 +997,17 @@ statements, move forward one more.
 
 TODO: Document IN-CASE, NO-COMMAS."
   (dylan-skip-whitespace-forward)
-  (let ((dot (point)))
-    ;; skip over "separator words"
-    (if (looking-at dylan-separator-word-pattern)
-        (if (not (looking-at "exception\\|elseif"))
-            (forward-word 1)
-          (goto-char (match-end 0))
-          (condition-case nil (forward-list 1)
-            (error nil))))
-    (cond ((not (dylan-find-end t in-case no-commas))
-           (if (dylan-look-back "\\(define\\|local\\)[ \t]+")   ; hack
-               (goto-char (match-beginning 0))))
-          (t)))
+  ;; skip over "separator words"
+  (if (looking-at dylan-separator-word-pattern)
+      (if (not (looking-at "exception\\|elseif"))
+          (forward-word 1)
+        (goto-char (match-end 0))
+        (condition-case nil (forward-list 1)
+          (error nil))))
+  (cond ((not (dylan-find-end t in-case no-commas))
+         (if (dylan-look-back "\\(define\\|local\\)[ \t]+")   ; hack
+             (goto-char (match-beginning 0))))
+        (t))
   (cond ((looking-at "[,;]$") (forward-char))
         ((looking-at "=>") (forward-word 1))))
 
@@ -1284,7 +1283,7 @@ newlines and closing punctuation are needed."
   "Move backward to next beginning of definition. With ARG, do this ARG times."
   (interactive "p")
   (let ((header-end (dylan-header-end)))
-    (dotimes (i (or arg 1))
+    (dotimes (_i (or arg 1))
       (unless (< (point) header-end)
         (when (re-search-backward dylan-defun-regexp header-end t 1)
           (beginning-of-line))))))
@@ -1292,7 +1291,7 @@ newlines and closing punctuation are needed."
 (defun dylan-end-of-defun (&optional arg)
   "Move forward to next end of function. With ARG, do this ARG times."
   (interactive "p")
-  (dotimes (i (or arg 1))
+  (dotimes (_i (or arg 1))
     (let ((dot (point)))
       (dylan-skip-whitespace-forward)   ; why?
       (end-of-line)

--- a/dylan-mode.el
+++ b/dylan-mode.el
@@ -48,16 +48,6 @@
 ;; their values, frequently the easiest way to test changes is to start a new
 ;; Emacs.
 
-;; Bugs / to-do list
-;;
-;; * See bugs on GitHub: https://github.com/dylan-lang/dylan-mode/issues
-;; * Don't highlight macro variables (e.g., "?x:" in ?x:name) as keywords.
-;;   Just highlight the "x" as a variable binding.
-;; * Customize fill-column to some acceptable value so that auto-filled
-;;   comments are filled at a standard place > 70.  I use 89 myself.
-;; * It appears as though some code matches only some of the graphic-character
-;;   BNF when it should match all graphic chars.
-
 ;;; Code:
 
 

--- a/dylan-mode.el
+++ b/dylan-mode.el
@@ -39,10 +39,10 @@
 
 ;; Debugging
 ;;
-;; So far I (cgay) have found it easiest to debug by adding calls to (message ...) all
-;; over the place and keep the *Messages* window visible, since tracing doesn't say the
-;; names of the arguments or return values.  If someone else knows a better way please
-;; comment.
+;; So far I (cgay) have found it easiest to debug by adding calls to
+;; (message ...) all over the place and keep the *Messages* window
+;; visible, since tracing doesn't say the names of the arguments or
+;; return values. If someone else knows a better way please comment.
 ;;
 ;; With so many cascading defvars and the fact that eval-buffer doesn't reset
 ;; their values, frequently the easiest way to test changes is to start a new
@@ -135,15 +135,16 @@ whitespace prefix."
 ;;; Regular expressions -- See https://opendylan.org/books/drm/Lexical_Grammar
 
 (defconst dylan-graphic-character "!&*<>|^$%@_")
-(defconst dylan-special-character "-+~?/=")   ; code may assume '-' comes first
+(defconst dylan-special-character "-+~?/=") ; code may assume '-' comes first
 
 ;;; For Dylan `name` BNF special care has to be taken to handle leading
 ;;; numerics and leading graphics.
 (defconst dylan-name-pattern
-  (format "\\([a-zA-Z]\\|[0-9][a-zA-Z][a-zA-Z]\\|[%s][a-zA-Z]\\)[%s%sa-zA-Z0-9]*"
-          dylan-graphic-character
-          dylan-special-character             ; intentionally follows '[' in regex
-          dylan-graphic-character))
+  (format
+   "\\([a-zA-Z]\\|[0-9][a-zA-Z][a-zA-Z]\\|[%s][a-zA-Z]\\)[%s%sa-zA-Z0-9]*"
+   dylan-graphic-character
+   dylan-special-character   ; intentionally follows '[' in regex
+   dylan-graphic-character))
 
 (defconst dylan-keyword-symbol-pattern
   (format "%s:" dylan-name-pattern))
@@ -166,7 +167,8 @@ whitespace prefix."
     "class"
     ;; C-FFI
     "C-subtype" "C-mapped-subtype")
-  ;; TODO(cgay): It seems like a lie that these are parameterized "like 'define method'".
+  ;; TODO(cgay): It seems like a lie that these are parameterized
+  ;; "like 'define method'".
   ;; The superclass is a type spec only, without a variable name.
   "Words that introduce type definitions like \"define class\".
 
@@ -272,15 +274,17 @@ expression or a list of regular expressions. A set of balanced
 parens will be matched between each list element.")
 
 (defvar dylan-font-lock-header-keywords
-  ;; Many of these regexp patterns are order-dependent, assuming the preceding
-  ;; patterns have already been matched and fontified as appropriate, preventing
-  ;; following patterns from being used to fontify the same text.
+  ;; Many of these regexp patterns are order-dependent, assuming the
+  ;; preceding patterns have already been matched and fontified as
+  ;; appropriate, preventing following patterns from being used to
+  ;; fontify the same text.
   ;;
-  ;; Most of these patterns match up to the end of buffer, so that highlighting
-  ;; occurs while entering header text in a new Dylan file. Notably, the pattern
-  ;; for invalid header lines does not, so that it doesn't mark incomplete lines
-  ;; as invalid while the user is still entering them. (It does mark even
-  ;; temporarily invalid lines that aren't at the end of buffer, though.)
+  ;; Most of these patterns match up to the end of buffer, so that
+  ;; highlighting occurs while entering header text in a new Dylan
+  ;; file. Notably, the pattern for invalid header lines does not, so
+  ;; that it doesn't mark incomplete lines as invalid while the user
+  ;; is still entering them. (It does mark even temporarily invalid
+  ;; lines that aren't at the end of buffer, though.)
   `(
     ;; The "module:" header line. Highlight the module name.
     (,(concat "^"
@@ -296,12 +300,13 @@ parens will be matched between each list element.")
             'dylan-header-module-name
           'dylan-header-error)))
 
-    ;; The "language:" header line. Highlight the language name. This is a bit
-    ;; of pedantry on my part -- this header is rarely used, except perhaps in
-    ;; very old files -- so I'm just using the same face as for the module name,
-    ;; rather than defining a separate face (or renaming the module name face to
-    ;; be more generic). "infix-dylan" is the only portable value, so let's warn
-    ;; about other values.
+    ;; The "language:" header line. Highlight the language name. This
+    ;; is a bit of pedantry on my part -- this header is rarely used,
+    ;; except perhaps in very old files -- so I'm just using the same
+    ;; face as for the module name, rather than defining a separate
+    ;; face (or renaming the module name face to be more generic).
+    ;; "infix-dylan" is the only portable value, so let's warn about
+    ;; other values.
     (,(concat "^"
               "language:"               ; keyword
               "[ \t]*"                  ; space
@@ -341,8 +346,8 @@ parens will be matched between each list element.")
               "[^\n]*\n")               ; rest of line
      . 'dylan-header-error)
 
-    ;; Mark all lines in the header with the header background face (except for
-    ;; the final, blank line).
+    ;; Mark all lines in the header with the header background face
+    ;; (except for the final, blank line).
     (,(concat "^"
               "[ \t]*"                  ; possible continuation prefix
               "[^ \t\n]+"               ; any non-whitespace in line
@@ -412,12 +417,13 @@ define word or other parts of the definition macro call.")
 
 (defvar dylan-separator-word-pattern
   (regexp-opt dylan-separator-words 'symbols)
-  ;; Try to find a way to make these context-sensitive, so they are only
-  ;; highlighted within the appropriate statements. Unfortunately, doing this
-  ;; robustly may require knowing the syntax of all statement macros and parsing
-  ;; them so we don't highlight separators when they're within nested
-  ;; statements. On the other hand, we may get a lot of mileage out of just
-  ;; handling all the iteration words in for statements.
+  ;; Try to find a way to make these context-sensitive, so they are
+  ;; only highlighted within the appropriate statements.
+  ;; Unfortunately, doing this robustly may require knowing the syntax
+  ;; of all statement macros and parsing them so we don't highlight
+  ;; separators when they're within nested statements. On the other
+  ;; hand, we may get a lot of mileage out of just handling all the
+  ;; iteration words in for statements.
   "Separator words in statement macros.")
 
 (defvar dylan-constant-simple-definition-pattern
@@ -470,8 +476,8 @@ the various keyword list variables."
                        dylan-simple-definition-pattern)
                dylan-other-words))
   (setq dylan-body-start-expressions
-        ;; cpage 2007-04-06: Why are these listed here? Shouldn't we build these
-        ;; patterns from dylan-statement-words?
+        ;; cpage 2007-04-06: Why are these listed here? Shouldn't we
+        ;; build these patterns from dylan-statement-words?
         `(("if[ \t\n]*" "")
           ("block[ \t\n]*" "")
           ("for[ \t\n]*" "")
@@ -523,9 +529,10 @@ Uses the values of the various pattern variables."
   ;; moving some keyword patterns from 1 to 0, or by moving 2 to 3 and moving
   ;; some from 1 to 2.
 
-  ;; TODO(cgay): For me personally, I don't want most Dylan reserved words,
-  ;; like "define", "method", "macro", to be highlighted specially. Those are
-  ;; the necessary background noise of the language and don't need calling out.
+  ;; TODO(cgay): For me personally, I don't want most Dylan reserved
+  ;; words, like "define", "method", "macro", to be highlighted
+  ;; specially. Those are the necessary background noise of the
+  ;; language and don't need calling out.
   ;; I like
   ;;   * Newly introduced bindings
   ;;     - let bindings
@@ -577,14 +584,18 @@ Uses the values of the various pattern variables."
                             "[ \t]*(")
                    1 font-lock-warning-face)
                   ;; Definition starts
-                  (,(concat "\\_<\\(" dylan-define-pattern
-                            "\\(" dylan-constant-simple-definition-pattern "\\|"
-                            dylan-variable-simple-definition-pattern "\\|"
-                            dylan-other-simple-definition-pattern "\\)"
-                            "\\)\\_>[ \t]+\\(\\(\\s_\\|\\w\\)+\\)")
-                   (7 (cond ((match-beginning 4) 'font-lock-constant-face)
-                            ((match-beginning 5) 'font-lock-variable-name-face)
-                            (t 'font-lock-function-name-face))))
+                  (,(concat
+                     "\\_<\\(" dylan-define-pattern
+                     "\\(" dylan-constant-simple-definition-pattern "\\|"
+                     dylan-variable-simple-definition-pattern "\\|"
+                     dylan-other-simple-definition-pattern "\\)"
+                     "\\)\\_>[ \t]+\\(\\(\\s_\\|\\w\\)+\\)")
+                   (7 (cond ((match-beginning 4)
+                             'font-lock-constant-face)
+                            ((match-beginning 5)
+                             'font-lock-variable-name-face)
+                            (t
+                             'font-lock-function-name-face))))
                   (,(concat "\\_<\\(" dylan-define-pattern
                             dylan-definition-pattern "\\)")
                    1 font-lock-keyword-face)
@@ -608,17 +619,21 @@ Uses the values of the various pattern variables."
                    (3 (cond ((match-beginning 2) 'font-lock-type-face)
                             (t 'font-lock-function-name-face)))))))
 
-  ;; Decoration level 2: Highlight all function and local variable definitions,
-  ;; and, optionally, all function calls.
+  ;; Decoration level 2: Highlight all function and local variable
+  ;; definitions, and, optionally, all function calls.
   (setq dylan-font-lock-keywords-2
-        (append dylan-font-lock-keywords-1
-                '(("slot[ \t\n]+\\(\\(\\sw\\|\\s_\\)+\\)" 1 font-lock-variable-name-face)
-                  ("block[ \t\n]+(\\([^)]+\\)" 1 font-lock-function-name-face)
-                  ("let[ \t\n]+\\(\\(\\sw\\|\\s_\\)+\\)" 1 font-lock-variable-name-face)
-                  ;; This highlights commas and whitespace separating the
-                  ;; variable names. Try to find a way to highlight only the
-                  ;; variable names.
-                  ("let[ \t\n]+(\\([^)]+\\)" 1 font-lock-variable-name-face))))
+        (append
+         dylan-font-lock-keywords-1
+         '(("slot[ \t\n]+\\(\\(\\sw\\|\\s_\\)+\\)"
+            1 font-lock-variable-name-face)
+           ("block[ \t\n]+(\\([^)]+\\)"
+            1 font-lock-function-name-face)
+           ("let[ \t\n]+\\(\\(\\sw\\|\\s_\\)+\\)"
+            1 font-lock-variable-name-face)
+           ;; This highlights commas and whitespace separating the
+           ;; variable names. Try to find a way to highlight only the
+           ;; variable names.
+           ("let[ \t\n]+(\\([^)]+\\)" 1 font-lock-variable-name-face))))
   (when dylan-highlight-function-calls
     (setq dylan-font-lock-keywords-2
           (append dylan-font-lock-keywords-2
@@ -645,7 +660,7 @@ note that this will only work within the current line."
 Including parenthesized expressions.")
 
 (defvar dylan-beginning-of-form-pattern nil
-  "Like `dylan-find-keyword-pattern', but also matches statement terminators.")
+  "Like `dylan-find-keyword-pattern' but also matches statement terminators.")
 
 (defun dylan-header-end ()
   "Get the position of the end of the interchange file header.
@@ -667,8 +682,8 @@ so we can handle them separately, whether they are well-formed or not."
                (point))
           (point-max)))))
 
-(defun dylan-backward-find-keyword (&optional match-statement-end in-case no-commas
-                                              _start)
+(defun dylan-backward-find-keyword
+    (&optional match-statement-end in-case no-commas _start)
   "Find the previous keyword.
 
 Move point backward to the beginning of the innermost enclosing
@@ -680,10 +695,10 @@ TODO: Document MATCH-STATEMENT-END, IN-CASE, NO-COMMAS, START."
   (let ((header-end (dylan-header-end))
         (result 'not-found))
     (while (and (>= (point) header-end) (eq result 'not-found))
-      ;; cpage 2007-04-14: This could handle block comments better. The
-      ;; re-search-backward pattern doesn't skip over them, and
-      ;; dylan-skip-whitespace-backward can't skip over a block comment if point
-      ;; is inside it.
+      ;; cpage 2007-04-14: This could handle block comments better.
+      ;; The re-search-backward pattern doesn't skip over them, and
+      ;; dylan-skip-whitespace-backward can't skip over a block
+      ;; comment if point is inside it.
       (setq
        result
        (if (re-search-backward (if match-statement-end
@@ -720,21 +735,24 @@ TODO: Document MATCH-STATEMENT-END, IN-CASE, NO-COMMAS, START."
                        (not (looking-at dylan-keyword-pattern)))
                   nil)
                  ;; Skip backward over blocks/statements that end with "end".
-                 ((or (looking-at "end")            ; Point is either before or
+                 ((or (looking-at "end")        ; Point is either before or
                       (and (dylan-look-back "\\_<end[ \t]*$") ; after "end".
                            (backward-word 1)))
-                  (dylan-backward-find-keyword)  ; Search for the start of the block.
+                  ;; Search for the start of the block.
+                  (dylan-backward-find-keyword)
                   ;; cpage 2007-05-17: Why does this check for "method" and
                   ;; "define"? Should it also check for "define...function"?
                   ;; What about "define...class", etc.?
                   (if (or (and (looking-at "method")
-                               (dylan-look-back "define\\([ \t\n]+\\w+\\)*[ \t]+$"))
+                               (dylan-look-back
+                                "define\\([ \t\n]+\\w+\\)*[ \t]+$"))
                           (looking-at "define"))
                       nil
                     'not-found))
-                 ;; cpage 2007-05-17: What is this for? Does it handle `until:'
-                 ;; and `while:' within `for' iteration clauses? Shouldn't it
-                 ;; test for the keywords with the colon?
+                 ;; cpage 2007-05-17: What is this for? Does it handle
+                 ;; `until:' and `while:' within `for' iteration
+                 ;; clauses? Shouldn't it test for the keywords with
+                 ;; the colon?
                  ;;
                  ;; hack for overloaded uses of "while" and "until" words
                  ((or (looking-at "until") (looking-at "while"))
@@ -920,7 +938,9 @@ that starts at the current point."
                      (t (if (looking-at (car exprs))
                             (match-end 0)
                           (dylan-find-body-start (cdr exprs)))))))
-    ;; Skip end-of-line comments that occur immediately after a start expression.
+    ;; Skip end-of-line comments that occur immediately after a start
+    ;; expression.
+    ;;
     ;; Example: method foo () => () // here
     ;; Example: method foo () // here
     ;;                  => ()
@@ -956,7 +976,7 @@ TODO: Document IN-CASE, NO-COMMAS."
           (re-search-backward dylan-separator-word-pattern header-end t)
           (dylan-skip-whitespace-backward))
         (if (dylan-look-back "[,;]$\\|=>$")
-            (backward-char))            ; TODO(cgay): should go back 2 for "=>" ?
+            (backward-char))    ; TODO(cgay): should go back 2 for "=>" ?
         (cond ((not (dylan-backward-find-keyword t in-case no-commas))
                (if (dylan-look-back "\\(define\\|local\\)[ \t]+") ; hack
                    (goto-char (match-beginning 0))))
@@ -975,7 +995,8 @@ TODO: Document IN-CASE, NO-COMMAS."
               (t
                ;; check whether we were already at the first "form" in an
                ;; enclosing block
-               (let ((first (dylan-find-body-start dylan-body-start-expressions)))
+               (let ((first (dylan-find-body-start
+                             dylan-body-start-expressions)))
                  (if (< first dot)
                      (goto-char first)
                    (if (dylan-look-back "\\(define\\|local\\)[ \t]+") ; hack
@@ -1033,7 +1054,8 @@ That contains or begins at the current point."
         (dylan-indent-header-line)
       (dylan-indent-code-line)))
 
-  ;; Move forward to this line's indentation level if cursor is to the left of it.
+  ;; Move forward to this line's indentation level if cursor is to the
+  ;; left of it.
   (when (< (current-column) (current-indentation))
     (back-to-indentation)))
 
@@ -1043,40 +1065,49 @@ That contains or begins at the current point."
   ;; section should indent, probably like this:
   ;;     Synopsis: blah blah
   ;;               blah blah
-  (when (called-interactively-p 'interactive) ; TODO: this is strongly discouraged
+  ;;
+  ;; TODO: `called-interactively-p' is strongly discouraged.
+  (when (called-interactively-p 'interactive)
     (when (<= (current-column) (current-indentation))
       (back-to-indentation))
     (insert-char ?\  dylan-indent)))
 
 (defun dylan-indent-code-line ()
   "Indent a code line (i.e. not a header line)."
-  ;; Move point to the end of the current indentation. This allows us to use looking-at
-  ;; to examine the start of the current line of code without having to put whitespace at
-  ;; the start of all the patterns.
+  ;; Move point to the end of the current indentation. This allows us
+  ;; to use looking-at to examine the start of the current line of
+  ;; code without having to put whitespace at the start of all the
+  ;; patterns.
   (back-to-indentation)
-  (cl-multiple-value-bind (body-start in-paren paren-indent in-case block-indent)
+  (cl-multiple-value-bind
+      (body-start in-paren paren-indent in-case block-indent)
       (dylan-find-indent-context)
-    ;; This is useful enough for debugging that I'm leaving it (commented out) for now. --cgay
-    ;;(message "body-start = %S, in-paren = %S, paren-indent = %S, in-case = %S, block-indent = %S"
+    ;; This is useful enough for debugging that I'm leaving it
+    ;; (commented out) for now. --cgay
+    ;;
+    ;; (message "body-start = %S, in-paren = %S, paren-indent = %S, in-case = %S, block-indent = %S"
     ;;         body-start in-paren paren-indent in-case block-indent)
     (let ((indent                       ; correct indentation for this line
            (cond ((not block-indent)
                   (dylan-indent-if-continuation ";" (point) 0))
                  ;; Some keywords line up with start of compound statement.
-                 ((looking-at dylan-separator-word-pattern) ; e.g., "else" or "finally"
+                 ((looking-at dylan-separator-word-pattern)
+                  ;; e.g., "else" or "finally"
                   block-indent)
                  ;; End keywords line up with start of compound statement.
                  ((looking-at dylan-end-keyword-pattern)
                   block-indent)
                  ;; Parenthesized expressions, separated by commas.
                  (in-case
-                  ;; If the line is blank, we pick an arbitrary indentation for now. We
-                  ;; judge the "proper" indentation by how the statement is punctuated
+                  ;; If the line is blank, we pick an arbitrary
+                  ;; indentation for now. We judge the "proper"
+                  ;; indentation by how the statement is punctuated
                   ;; once it is finished.
                   (cond ((looking-at "^[ \t]*$")
                          (if (save-excursion
-                               ;; Look for end of prev statement. This is hairier than it
-                               ;; should be because we may be at the end of the buffer.
+                               ;; Look for end of prev statement. This
+                               ;; is hairier than it should be because
+                               ;; we may be at the end of the buffer.
                                (let ((dot (point)))
                                  (dylan-forward-statement t)
                                  (dylan-skip-whitespace-backward)
@@ -1099,21 +1130,26 @@ That contains or begins at the current point."
                               (dylan-indent-if-continuation
                                "," (point) body-start t)))))
                  (in-paren
-                  (let ((cindent (dylan-indent-if-continuation "," (point) body-start)))
+                  (let ((cindent (dylan-indent-if-continuation
+                                  "," (point) body-start)))
                     (+ block-indent paren-indent cindent)))
-                 ;; Cursor is (for example) before the end of the parameter list that is
-                 ;; on a new line in a "define function" or before the parens in
-                 ;; "block\n()".
+                 ;; Cursor is (for example) before the end of the
+                 ;; parameter list that is on a new line in a "define
+                 ;; function" or before the parens in "block\n()".
                  ((< (point) body-start)
                   (+ block-indent
-                     (if (save-excursion (back-to-indentation) (looking-at "=>"))
-                         ;; Outdent return value spec to align with parameters.
+                     (if (save-excursion
+                           (back-to-indentation)
+                           (looking-at "=>"))
+                         ;; Outdent return value spec to align with
+                         ;; parameters.
                          (- dylan-continuation-indent 1)
                        (+ dylan-continuation-indent 2))))
                  ;; Statements separated by semicolons.
                  (t
                   (+ block-indent dylan-indent
-                     (dylan-indent-if-continuation ";" (point) body-start))))))
+                     (dylan-indent-if-continuation
+                      ";" (point) body-start))))))
       (unless (= indent (current-indentation))
         (save-excursion
           (beginning-of-line)
@@ -1124,23 +1160,26 @@ That contains or begins at the current point."
   "Helper to find context for Dylan indentation."
   (let* ((start-pos (point))
          (body-start)
-         ;; This may be treated as a boolean, but when true its value is a string
-         ;; containing the open paren character we saw. i.e., "(", "{", or "["
+         ;; This may be treated as a boolean, but when true its value
+         ;; is a string containing the open paren character we saw.
+         ;; i.e., "(", "{", or "["
          (in-paren)
          ;; How much to indent expressions inside parens relative to
-         ;; block-indent. Normally this is 1, but it may be negative if the first
-         ;; expression is on a new line, and may be increased following #key in a
-         ;; parameter list.
+         ;; block-indent. Normally this is 1, but it may be negative
+         ;; if the first expression is on a new line, and may be
+         ;; increased following #key in a parameter list.
          (paren-indent)
          (in-case)
-         ;; The basic indentation for the current compound statement. However, the
-         ;; ultimate indentation may depend on whether in-paren is true or not.
+         ;; The basic indentation for the current compound statement.
+         ;; However, the ultimate indentation may depend on whether
+         ;; in-paren is true or not.
          (block-indent
           (save-excursion
             (when (dylan-backward-find-keyword)
               (and (looking-at "method")
-                   ;; TODO(cgay): rename dylan-look-back to dylan-this-line-has
-                   ;; or something that indicates the scope of the search.
+                   ;; TODO(cgay): rename dylan-look-back to
+                   ;; dylan-this-line-has or something that indicates
+                   ;; the scope of the search.
                    (dylan-look-back "define\\([ \t\n]+\\w+\\)*[ \t]+$")
                    (goto-char (match-beginning 0)))
               (when (looking-at "[[({]")
@@ -1148,31 +1187,41 @@ That contains or begins at the current point."
                 (save-excursion
                   (let ((paren-pos (point)))
                     (when (equal in-paren "(")
-                      (let ((key-pos (save-excursion
-                                       (goto-char start-pos)
-                                       (re-search-backward "#key\\( \\|$\\)" paren-pos t))))
+                      (let ((key-pos
+                             (save-excursion
+                               (goto-char start-pos)
+                               (re-search-backward
+                                "#key\\( \\|$\\)" paren-pos t))))
                         (when key-pos
-                          ;; TODO(cgay): for now this sort of assumes that #key starts on
-                          ;; a new line or right after the open paren. Could be smarter
-                          ;; for code like: foo(blah, blah, blah, blah, #key x = 1\ny=2)
-                          ;; 6 is for the "(" and "#key ".
-                          (setq paren-indent 6)))) ; Align to the right of "#key ".
+                          ;; Align to the right of "#key ".
+                          ;;
+                          ;; TODO(cgay): for now this sort of assumes
+                          ;; that #key starts on a new line or right
+                          ;; after the open paren. Could be smarter
+                          ;; for code like: foo(blah, blah, blah,
+                          ;; blah, #key x = 1\ny=2) 6 is for the "("
+                          ;; and "#key ".
+                          (setq paren-indent 6))))
                     (unless paren-indent
                       (forward-char)               ; move past paren
                       (re-search-forward "[^ \t]") ; and whitespace
-                      ;; TODO(cgay): seems the following not needed if at end of buffer?
-                      (backward-char)              ; above skips first non-white char
-                      ;; TODO(cgay): if looking-at("$") figure out how much to outdent to
-                      ;; put function call args dylan-continuation-indent to the right of
-                      ;; the start of the function name.
+                      ;; TODO(cgay): seems the following not needed if
+                      ;; at end of buffer?
+                      (backward-char) ; above skips first non-white char
+                      ;; TODO(cgay): if looking-at("$") figure out how
+                      ;; much to outdent to put function call args
+                      ;; dylan-continuation-indent to the right of the
+                      ;; start of the function name.
                       (setq paren-indent (- (point) paren-pos))))))
               (when (looking-at "select\\|case")
                 (setq in-case t))
-              (setq body-start (dylan-find-body-start dylan-body-start-expressions))
+              (setq body-start
+                    (dylan-find-body-start dylan-body-start-expressions))
               (current-column)))))
     (cl-values body-start in-paren paren-indent in-case block-indent)))
 
-(defun dylan-indent-if-continuation (term-char line-start block-start &optional in-case)
+(defun dylan-indent-if-continuation
+    (term-char line-start block-start &optional in-case)
   "Calculate extra indent (maybe negative) for an unfinished construct.
 
 TERM-CHAR is normally \",\" if in parentheses or \";\" otherwise.
@@ -1219,8 +1268,8 @@ TODO: Document IN-CASE."
 
 ;;; Motion:
 
-;; This intensely DWIMish function tries to insert whatever text is needed to
-;; finish off the enclosing indentation context.
+;; This intensely DWIMish function tries to insert whatever text is
+;; needed to finish off the enclosing indentation context.
 (defun dylan-insert-block-end ()
   "Insert whatever is needed to finish off enclosing indentation context.
 
@@ -1280,7 +1329,9 @@ newlines and closing punctuation are needed."
   "Regular expression identifying the beginning of a definition.")
 
 (defun dylan-beginning-of-defun (&optional arg)
-  "Move backward to next beginning of definition. With ARG, do this ARG times."
+  "Move backward to next beginning of definition.
+
+With ARG, do this ARG times."
   (interactive "p")
   (let ((header-end (dylan-header-end)))
     (dotimes (_i (or arg 1))
@@ -1289,14 +1340,17 @@ newlines and closing punctuation are needed."
           (beginning-of-line))))))
 
 (defun dylan-end-of-defun (&optional arg)
-  "Move forward to next end of function. With ARG, do this ARG times."
+  "Move forward to next end of function.
+
+With ARG, do this ARG times."
   (interactive "p")
   (dotimes (_i (or arg 1))
     (let ((dot (point)))
       (dylan-skip-whitespace-forward)   ; why?
       (end-of-line)
-      (let ((next-begin (or (re-search-forward dylan-defun-regexp nil 'move 1)
-                            (point-max))))
+      (let ((next-begin
+             (or (re-search-forward dylan-defun-regexp nil 'move 1)
+                 (point-max))))
         (beginning-of-line)
         (let ((last-end (re-search-backward "^ *end\\s-" nil 'move 1)))
           (if (and last-end (< last-end next-begin) (> last-end dot))
@@ -1334,8 +1388,8 @@ LOUDLY is as for `font-lock-fontify-region'."
         (save-restriction
           (narrow-to-region 1 end)
           (font-lock-default-fontify-region beg end loudly))))
-    ;; Fontify the Dylan code. We narrow the buffer to exclude the header from
-    ;; character syntactic fontification.
+    ;; Fontify the Dylan code. We narrow the buffer to exclude the
+    ;; header from character syntactic fontification.
     (when (> end header-end)
       (let ((beg (max beg header-end))
             (font-lock-dont-widen t))
@@ -1423,8 +1477,8 @@ DEPTH is the current lookup nesting depth."
 
 ;;;###autoload
 (define-derived-mode dylan-mode prog-mode "Dylan"
-  ;; TODO(cgay): document how to make indentation work correctly by adding your
-  ;; macro names to the appropriate variables.
+  ;; TODO(cgay): document how to make indentation work correctly by
+  ;; adding your macro names to the appropriate variables.
   "Major mode for editing Dylan programs.
 
 This mode may be customized with the options in the `dylan'

--- a/dylan-opt.el
+++ b/dylan-opt.el
@@ -1,4 +1,4 @@
-;;; dylan-opt.el --- Dylan optimization faces -*- lexical-binding: t -*-
+;;; dylan-opt.el --- Dylan optimization minor mode -*- lexical-binding: t -*-
 
 ;; Author: Hannes Mehnert
 ;; Author: Lassi Kortela

--- a/dylan-opt.el
+++ b/dylan-opt.el
@@ -21,7 +21,7 @@
 
 (require 'cl-lib)
 
-(require 'dylan-mode)
+(require 'dylan)
 
 (defgroup dylan-opt nil
   "Major mode for editing Dylan source code."

--- a/dylan-test.dylan
+++ b/dylan-test.dylan
@@ -1,4 +1,4 @@
-Module: dylan-mode-test
+Module: dylan-test
 Synopsis: This file can be used to test dylan-mode indentation, and to some extent
           the highlighting code.  It's not meant to be compiled.  Pressing the Tab
           key on any line in this file should not cause any changes; if it does it's
@@ -151,7 +151,7 @@ define macro foo-definer
  clauses:                       // ***
     { stuff }
  => { other stuff }             // ***
-    
+
 end;
 
 define test foo (option: bar)

--- a/dylan.el
+++ b/dylan.el
@@ -1,4 +1,4 @@
-;;; dylan.el --- Major mode for the Dylan programming language -*- lexical-binding: t -*-
+;;; dylan.el --- Dylan programming language modes -*- lexical-binding: t -*-
 
 ;; Copyright (C) 1994, 1995, 1996  Carnegie Mellon University
 ;; Copyright (C) 2004, 2005, 2007  Chris Page

--- a/dylan.el
+++ b/dylan.el
@@ -1,4 +1,4 @@
-;;; dylan-mode.el --- Major mode for the Dylan programming language -*- lexical-binding: t -*-
+;;; dylan.el --- Major mode for the Dylan programming language -*- lexical-binding: t -*-
 
 ;; Copyright (C) 1994, 1995, 1996  Carnegie Mellon University
 ;; Copyright (C) 2004, 2005, 2007  Chris Page
@@ -33,7 +33,7 @@
 
 ;; Testing
 ;;
-;; dylan-mode-test.dylan contains Dylan code that is indented in the preferred way. One
+;; dylan-test.dylan contains Dylan code that is indented in the preferred way. One
 ;; way to test this code is to open that file and press Tab on each line, or on the
 ;; specific lines you're trying to affect.
 
@@ -1514,6 +1514,6 @@ during initialization.
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.dylan\\'" . dylan-mode))
 
-(provide 'dylan-mode)
+(provide 'dylan)
 
-;;; dylan-mode.el ends here
+;;; dylan.el ends here


### PR DESCRIPTION
More issue #41 stuff.

These commits fix all Emacs byte-compiler warnings. They also fix all package-lint warnings except spurious ones having to do with versioning of the package.