### PR TITLE
Don't match ...ing words in dylan-with-statement-prefix

### DIFF
--- a/dylan.el
+++ b/dylan.el
@@ -204,10 +204,10 @@ These must also be simple definitions and are appended to
     "iterate" "profiling")
   "Words that begin statements with implicit bodies.")
 
-;; Names beginning "with-", "without-", and "...ing-" (e.g., printing-object)
-;; are commonly used as statement macros.
+;; Names beginning "with-", "without-", and "printing-" (for printing-object
+;; and printing-logical-block) are commonly used as statement macros.
 (defvar dylan-with-statement-prefix
-  "\\(with\\|without\\|[a-zA-Z]+ing\\)-")
+  "\\(with\\|without\\|printing\\)-")
 
 (defvar dylan-statement-prefixes
   (concat "\\|\\_<" dylan-with-statement-prefix "[-_a-zA-Z?!*@<>$%]+"))


### PR DESCRIPTION
Instead just match `printing-`, so that at least printing-object and
printing-logical-block are indented correctly. Matching any "ing" word was far
too general, primarily because it matched names like `string-to-version`.