### PR TITLE
Update code block in README and add support for 'dynamic-bind' macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ Dime relies on a backend, `dswank`. To configure Dime and `dswank`,
 add these lines to your .emacs file, changing `YYYY.nn` as appropriate
 for your installed release of Open Dylan::
 
-    (dime-setup '(dime-repl dime-note-tree))
-    (setq dime-dylan-implementations
-          '((opendylan ("/opt/opendylan-YYYY.nn/bin/dswank")
-                       :env ("OPEN_DYLAN_USER_REGISTRIES=/opt/opendylan-YYYY.nn/sources/registry"))))
+```lisp
+(dime-setup '(dime-repl dime-note-tree))
+(setq dime-dylan-implementations
+      '((opendylan ("/opt/opendylan-YYYY.nn/bin/dswank")
+                    :env ("OPEN_DYLAN_USER_REGISTRIES=/opt/opendylan-YYYY.nn/sources/registry"))))
+```
 
 You will also want to add your own source registries to the
 `OPEN_DYLAN_USER_REGISTRIES` environment variable. Registry paths are

--- a/dylan.el
+++ b/dylan.el
@@ -201,7 +201,7 @@ These must also be simple definitions and are appended to
     "if" "block" "begin" "method" "case" "for" "select" "when" "unless"
     "until" "while"
     ;; Extensions
-    "collecting" "iterate" "profiling")
+    "collecting" "iterate" "profiling" "dynamic-bind")
   "Words that begin statements with implicit bodies.")
 
 ;; Names beginning "with-", "without-", and "printing-" (for printing-object
@@ -473,6 +473,7 @@ the various keyword list variables."
           ("iterate[ \t\n]+\\w+[ \t\n]*" "")
           ("profiling[ \t\n]*" "")
           ("collecting[ \t\n]*" "")
+          ("dynamic-bind[ \t\n]*" "")
           ;; Special patterns for "define method" and "define function", which
           ;; have a return value spec.
           ;; TODO(cgay): comments may appear before/in/after the signature.


### PR DESCRIPTION
This PR includes two separate updates:

1. Update README to highlight code block for better readability.
2. Introduce initial support for 'dynamic-bind' macro.